### PR TITLE
Bug fix to the parseTags function

### DIFF
--- a/src/components/TagsArray.js
+++ b/src/components/TagsArray.js
@@ -5,7 +5,7 @@ const parseTags = (mdContent) => {
   const lines = mdContent.split("\n");
 
   for (let i = 0; i < lines.length; i++) {
-    const value = lines[i];
+    const value = lines[i].replace("\r","");
 
     tags.push({
       value


### PR DESCRIPTION
I found a bug, possibly experienced by other window users, where the text editor adds a carriage return tag '\r' when pressing enter to go to the next line. 

Have a look at this stack overflow post: https://stackoverflow.com/questions/12747722/what-is-the-difference-between-a-line-feed-and-a-carriage-return#:~:text=448,was%20two%20steps.

This bug essentially causes the options for linked to and experience tag to not load up as the Experience tags will contain will be e.g. 'Company 1/r' where as the selected tag is 'Company 1'. 

Here's a screen shot where I'm logging out the options and the selected options:
<img width="904" alt="image" src="https://user-images.githubusercontent.com/28992353/234124521-6038c2dd-693f-45cc-a720-b5654ab19098.png">.


The big question is really: "Why does the setState action remove the '\r' tag  ?"